### PR TITLE
Actualizo Quiénes somos - Juan C

### DIFF
--- a/about.md
+++ b/about.md
@@ -223,8 +223,8 @@ permalink: /quienessomos/
         </div>
         <div class="right">
             <div class="description">
-                <h2>Juan Martín Ríos</h2>
-                <span><a href="mailto:juanchirios.jmr@gmail.com">juanchirios.jmr@gmail.com</a></span>
+                <h2>Juan Ignacio Cuiule</h2>
+                <span><a href="mailto:juanchicuiu@gmail.com">juanchicuiu@gmail.com</a></span>
             </div>
         </div>
 


### PR DESCRIPTION
Revisando el quiénes somos noté que JuanC no aparecía.
Lo puse en lugar de Juanchi que no está activo hace varios cuatris.